### PR TITLE
Add DynamicSupervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,13 @@ Now if the producer crashes, it will be restarted. You can test this by adding a
 random `raise "chaos monkey"` into the `Producer#call` loop. The error will be
 logged, the producer restarted and the application continue running.
 
+#### Dynamic Supervisor
+
+Identical to `Earl::Supervisor` but monitors a dynamic list of agents that can
+be started and stopped at any time during the application lifetime. If a
+monitored agent crashes, it will be restarted, but if it returns normally it
+will be removed from the monitoring list.
+
 #### Pool
 
 The `Earl::Pool(A, M)` agent spawns a fixed size list of agents of type `A`, to

--- a/src/dynamic_supervisor.cr
+++ b/src/dynamic_supervisor.cr
@@ -1,0 +1,105 @@
+require "syn/core/mutex"
+require "syn/core/wait_group"
+require "./agent"
+
+module Earl
+  # Supervises dynamic agents.
+  #
+  # The list of monitored agents is dynamic. Agents may only be added after the
+  # supervisor itself has started. Unlike `Supervisor` stopped agents will
+  # be removed from supervision; agents will only be restarting when they
+  # crash.
+  #
+  # Use a `DynamicSupervisor` to monitor agents that will be spawned by other
+  # agents after the program has started, and that can be stopped and restarted
+  # regularly. For example stateful sessions or an in-memory data source for
+  # sporadic usages.
+  #
+  # - Spawns agents in their dedicated `Fiber`.
+  # - Whenever a supervised agent stops, it will be removed from supervision.
+  # - Whenever a supervised agent crashes, it will be recycled and restarted.
+  # - The supervisor won't stop when all monitored agents have stopped. It must
+  #   be explicitely told to stop (in which case it will stop all agents).
+  class DynamicSupervisor
+    include Agent
+    include Logger
+
+    def initialize
+      @agents = Deque(Agent).new
+      @mutex = Syn::Core::Mutex.new(:unchecked)
+      @group = Syn::Core::WaitGroup.new(1) # supervisor must wait on itself (hence starting at 1)
+    end
+
+    # Adds an agent to supervise. The agent will be spawned immediately.
+    def monitor(agent : Agent) : Nil
+      raise ArgumentError.new("agents must be monitored after starting the dynamic supervisor") if starting?
+      raise ArgumentError.new("can't monitor running agents") unless agent.starting?
+
+      if message = monitor?(agent)
+        raise ArgumentError.new(message)
+      else
+        spawn_agent(agent)
+      end
+    end
+
+    protected def monitor?(agent : Agent) : String?
+      @mutex.synchronize do
+        return "can't monitor the same agent twice" if @agents.includes?(agent)
+        @agents << agent
+        nil
+      end
+    end
+
+    protected def spawn_agent(agent : Agent) : Nil
+      ::spawn do
+        while running? && agent.starting?
+          agent.start(link: self)
+        end
+      end
+      @group.add(1)
+    end
+
+    # Waits until all supervised agents have stopped and the supervisor itself
+    # is told to stop.
+    def call
+      @group.wait
+    end
+
+    # Recycles and restarts crashed agents. Removes stopped agent from
+    # supervision.
+    def trap(agent : Agent, exception : Exception?) : Nil
+      if exception
+        Logger.error(agent, exception)
+        log.error { "worker crashed (#{exception.class.name})" }
+
+        if running?
+          agent.recycle
+          return
+        end
+      end
+
+      @mutex.synchronize do
+        @agents.delete(agent)
+      end
+
+      @group.done # agent is done
+      sleep(0.seconds)
+    end
+
+    # Asks all supervised agents to stop.
+    def terminate : Nil
+      @mutex.synchronize do
+        @agents.reverse_each do |agent|
+          agent.stop if agent.running?
+        end
+      end
+      @group.done # supervisor is done
+    end
+
+    # Clears the list of supervised agents.
+    def reset : Nil
+      @group = Syn::Core::WaitGroup.new(1)
+      @agents.clear
+    end
+  end
+end

--- a/src/earl.cr
+++ b/src/earl.cr
@@ -5,6 +5,7 @@ require "./mailbox"
 require "./pool"
 require "./registry"
 require "./supervisor"
+require "./dynamic_supervisor"
 
 # For a generic introduction see `README.md`. For a formal description see
 # `SPEC.md`.

--- a/test/dynamic_supervisor_test.cr
+++ b/test/dynamic_supervisor_test.cr
@@ -1,0 +1,85 @@
+require "./test_helper"
+
+private class Pending
+  include Earl::Artist(Int32)
+
+  def call(arg : Int32)
+  end
+end
+
+private class Noop
+  include Earl::Agent
+
+  def initialize(@monkey = false)
+  end
+
+  def call
+    return unless @monkey
+    sleep 0
+    raise "chaos"
+  end
+end
+
+module Earl
+  class DynamicSupervisorTest < Minitest::Test
+    def test_starts_and_stops_monitored_agents
+      supervisor = spawn_supervisor
+
+      agents = [Pending.new, Pending.new, Pending.new]
+      agents.each { |agent| supervisor.monitor(agent) }
+      eventually { assert agents.all?(&.running?) }
+
+      supervisor.stop
+      eventually { assert supervisor.stopped? }
+      eventually { assert agents.all? { |a| a.stopped? || a.stopping? } }
+      assert_empty supervisor.@agents
+    end
+
+    def test_normal_termination_of_supervised_agents
+      supervisor = spawn_supervisor
+
+      agents = [Noop.new, Noop.new]
+      agents.each { |agent| supervisor.monitor(agent) }
+
+      eventually { assert agents.all? { |a| a.stopped? || a.stopping? } }
+
+      assert supervisor.running?
+      assert_empty supervisor.@agents
+    end
+
+    def test_recycles_supervised_agents
+      supervisor = spawn_supervisor
+
+      agent = Noop.new(monkey: true)
+      supervisor.monitor(agent)
+
+      10.times do
+        refute_empty supervisor.@agents
+        eventually { refute agent.crashed? }
+      end
+
+      supervisor.stop
+    end
+
+    def test_cant_monitor_until_supervisor_is_started
+      supervisor = DynamicSupervisor.new
+      assert_raises(ArgumentError) { supervisor.monitor(Noop.new) }
+    end
+
+    def test_cant_monitor_running_agent
+      supervisor = spawn_supervisor
+
+      pending = Pending.new.tap(&.spawn)
+      eventually { assert pending.running? }
+
+      assert_raises(ArgumentError) { supervisor.monitor(pending) }
+    end
+
+    private def spawn_supervisor
+      supervisor = DynamicSupervisor.new
+      supervisor.spawn
+      eventually { assert supervisor.running? }
+      supervisor
+    end
+  end
+end


### PR DESCRIPTION
Another agent supervisor for agents that may be started on-demand and stopped at any time _after_ `Earl.application` has started, unlike `Earl::Supervisor` that monitors a static list of agents defined _before_ the supervisor starts.

TODO:
- [x] Documentation

closes #7 